### PR TITLE
Add catalog database migration for access_blob.

### DIFF
--- a/tiled/catalog/core.py
+++ b/tiled/catalog/core.py
@@ -5,6 +5,7 @@ from .base import Base
 
 # This is list of all valid revisions (from current to oldest).
 ALL_REVISIONS = [
+    "9331ed94d6ac",
     "45a702586b2a",
     "ed3a4223a600",
     "e756b9381c14",

--- a/tiled/catalog/migrations/versions/9331ed94d6ac_add_access_blob_column_to_nodes.py
+++ b/tiled/catalog/migrations/versions/9331ed94d6ac_add_access_blob_column_to_nodes.py
@@ -1,0 +1,28 @@
+"""Add access_blob column to nodes
+
+Revision ID: 9331ed94d6ac
+Revises: 45a702586b2a
+Create Date: 2025-05-07 12:44:45.886279
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+from tiled.catalog.orm import JSONVariant
+
+# revision identifiers, used by Alembic.
+revision = "9331ed94d6ac"
+down_revision = "45a702586b2a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "nodes",
+        sa.Column("access_blob", JSONVariant, nullable=False, server_default="{}"),
+    )
+
+
+def downgrade():
+    op.drop_column("nodes", "access_blob")


### PR DESCRIPTION
Interactively tested:

```none
13:03 dallan@traveller:tiled [main]❯ sqlite3 -table catalog.db 'select * from nodes;'
+----+-----+-----------+------------------+----------+-------+---------------------+---------------------+
| id | key | ancestors | structure_family | metadata | specs |    time_created     |    time_updated     |
+----+-----+-----------+------------------+----------+-------+---------------------+---------------------+
| 1  | x   | []        | array            | {}       | []    | 2025-05-07 17:03:41 | 2025-05-07 17:03:41 |
+----+-----+-----------+------------------+----------+-------+---------------------+---------------------+
13:04 dallan@traveller:tiled [main]❯ git checkout authz-migration
Switched to branch 'authz-migration'
13:04 dallan@traveller:tiled [authz-migration]❯ tiled catalog upgrade-database catalog.db
13:05 dallan@traveller:tiled [authz-migration]❯ sqlite3 -table catalog.db 'select * from nodes;'
+----+-----+-----------+------------------+----------+-------+---------------------+---------------------+-------------+
| id | key | ancestors | structure_family | metadata | specs |    time_created     |    time_updated     | access_blob |
+----+-----+-----------+------------------+----------+-------+---------------------+---------------------+-------------+
| 1  | x   | []        | array            | {}       | []    | 2025-05-07 17:03:41 | 2025-05-07 17:03:41 | {}          |
+----+-----+-----------+------------------+----------+-------+---------------------+---------------------+-------------+
```

```
13:09 dallan@traveller:tiled [authz-migration]❯ psql postgresql://postgres:secret@localhost:5432/test_migration
psql (14.17 (Ubuntu 14.17-0ubuntu0.22.04.1), server 16.0 (Debian 16.0-1.pgdg120+1))
Type "help" for help.

test_migration=# select * from nodes;
 id | key | ancestors | structure_family | metadata | specs | time_created | time_updated
----+-----+-----------+------------------+----------+-------+--------------+--------------
(0 rows)

test_migration=#
\q
13:09 dallan@traveller:tiled [authz-migration]❯ tiled catalog upgrade-database postgresql://postgres:secret@localhost:5432/test_migration
13:10 dallan@traveller:tiled [authz-migration]❯ psql postgresql://postgres:secret@localhost:5432/test_migration
psql (14.17 (Ubuntu 14.17-0ubuntu0.22.04.1), server 16.0 (Debian 16.0-1.pgdg120+1))
Type "help" for help.

test_migration=# select * from nodes;
 id | key | ancestors | structure_family | metadata | specs | time_created | time_updated | access_blob
----+-----+-----------+------------------+----------+-------+--------------+--------------+-------------
(0 rows)

test_migration=#
```

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
