### PR TITLE
Place access_blob in item of new node.

### DIFF
--- a/tiled/client/container.py
+++ b/tiled/client/container.py
@@ -723,6 +723,10 @@ class Container(BaseClient, collections.abc.Mapping, IndexersMixin):
                 ds for ds in document.pop("data_sources")
             ]
 
+        # And for access_blob
+        if "access_blob" in document:
+            item["attributes"]["access_blob"] = document.pop("access_blob")
+
         # Merge in "id" and "links" returned by the server.
         item.update(document)
 


### PR DESCRIPTION
Fix for this issue:

```py
In [12]: x = c['test']['raw'].write_array([1,2,3], key='x')

In [13]: x.access_blob
Out[13]: {}

In [14]: c['test']['raw']['x']
Out[14]: <ArrayClient shape=(3,) chunks=((3,),) dtype=int64>

In [15]: c['test']['raw']['x'].access_blob
Out[15]: {'user': 'dallan'}

In [18]: x.refresh()
Out[18]: <ArrayClient shape=(3,) chunks=((3,),) dtype=int64>

In [19]: x.access_blob
Out[19]: {'user': 'dallan'}
```