### PR TITLE
Refactoring client-side cache to integrate Hishel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Write the date in place of the "Unreleased" in the case a new version is release
 
 ## Unreleased
 
+### Added
+
+- Refactored the client-side cache to integrate the Hishel library, includes modifications to the transport and context.
+
 ### Fixed
 
 - Skip the `array-ref` streaming-cache update in `put_data_source` when the

--- a/docs/source/explanations/caching.md
+++ b/docs/source/explanations/caching.md
@@ -10,7 +10,7 @@ opt-out path.
 Tiled has two kinds of caching:
 
 1. **Client-side response cache.** The Tiled Python client implements a standard
-   web cache, similar in both concept and implementation to a web browser's cache.
+   web cache with Hishel, similar in both concept and implementation to a web browser's cache.
 2. **Server-side resource cache.** The resource cache is used to cache file
    handles and related system resources, to avoid rapidly opening, closing,
    and reopening the same files while handling a burst of requests.
@@ -26,13 +26,13 @@ from tiled.client import from_uri
 
 client = from_uri("...")
 client.context.cache.clear()  # clear cache
-c.context.cache.filepath  # locate SQLite file
+client.context.cache.filepath  # locate SQLite file
 
 # Customize the cache.
 
-from tiled.client.cache import Cache
+from tiled.client.cache import TiledCache
 
-cache = Cache(
+cache = TiledCache(
     capacity=500_000_000,  # bytes
     max_item_size=500_000,  # bytes
     filepath="path/to/my_cache.db",

--- a/docs/source/explanations/client-side-cache.md
+++ b/docs/source/explanations/client-side-cache.md
@@ -48,7 +48,7 @@ In addition to the aforementioned constraints, `TiledCache` has other parameters
 
 The `filepath` parameter can be used to set the location that the cache will be stored at. It defaults to the user's Tiled directory / "http_response_cache.db".
 
-The `ttl` parameter, which stands for "Time to Live", determines how long an entry can be in the cache until it is deemed expired. Once a cached entry is considered expired, the next time that the automated cleanup runs that entry will be removed from the cache. The default value is `None`.
+The `default_ttl` parameter, which stands for "Time to Live", determines how long an entry can be in the cache until it is deemed expired. Once a cached entry is considered expired, the next time that the automated cleanup runs that entry will be removed from the cache. The default value is `None`.
 
 ## Streaming
 
@@ -99,7 +99,7 @@ The `size` and `count` functions are used to gather information for the cache in
 
 ### `_remove_expired_caches`
 
-Once the time that a cached entry has been present in the cache exceeds the set time to live (`ttl`) value the entry would be considered expired and can be removed with the `_remove_expired_caches` function. This uses soft deletion, which is elaborated on in the next section.
+Once the time that a cached entry has been present in the cache exceeds the set time to live (`default_ttl`) value the entry would be considered expired and can be removed with the `_remove_expired_caches` function. This uses soft deletion, which is elaborated on in the next section.
 
 ## Soft Deletion
 

--- a/docs/source/explanations/client-side-cache.md
+++ b/docs/source/explanations/client-side-cache.md
@@ -1,0 +1,128 @@
+# Client-Side Cache
+
+## Overview
+
+The client-side cache makes retrieving data faster, especially when it comes to large amounts of data. The cache integrates the Hishel library. If the cache is set in the transport (`TiledTransport`), then when a request is intercepted by the transport it will check if the requested information is already in the cache prior to going to the server for the requested data. If the data is already stored in the cache, that is considered a cache hit and the data will be given to the user. Otherwise, that is a cache miss, and the data will have to be retrieved from the server.
+
+## SQL Database Set Up
+
+The SQL database is set up with two tables, one for the cache entries (`entries`) and one for the data that is being streamed (`streams`). Additionally, there is a table that contains the value of the cache version in case the cache gets updated in the future (this is used to ensure that the database is up to date with the version).
+
+### Entries Table
+
+The entries table consists of the following columns: `id`, `cache_key`, `data`, `created_at`, `deleted_at`, `size`, and `time_last_accessed`. The first 5 columns are created through Hishel, with the last two columns being added by Tiled to support necessary added functionality.
+
+### Streams Table
+
+The streams table consists of the following columns: `entry_id`, `chunk_number`, and `chunk_data`. The initialization of this table is entirely handled by Hishel.
+
+## Size Constraints
+
+The cache has size constraints when it comes to:
+(1) how many bytes are present in the cache total
+(2) how many bytes are in an individual entry.
+
+The former can be controlled by the setting of the `capacity` variable and the latter through `max_item_size` at the time of the cache creation. For example, the following code will have a limit of 2 GB for entry sizes and 4 GB for the overall cache size:
+
+```
+cache = TiledCache(max_item_size=2_000_000_000, capacity=4_000_000_000)
+```
+
+The default max item size is 500,000, and the default capacity is 500,000,000. The units are bytes.
+
+If the amount of items in the cache becomes too large and are over the capacity amount, an item will be evicted with the Least Recently Used (LRU) eviction method. This eviction method removes the entry that was accessed the longest time ago.
+
+The size of each entry is contributed by anything that is put into the SQL table, including the cache key, ID, data, and metadata.
+
+## Readonly Constraints
+
+The client-side cache can be in readonly mode in which entries cannot be put into the cache and any entries that are already in the cache cannot be updated/modified (including the value of `time_last_accessed`, which is used for LRU eviction). The default is that the cache will not be readonly, however it can be set to be readonly as shown below:
+
+```
+cache = TiledCache(readonly=True)
+```
+
+## Additional Cache Parameters
+
+In addition to the aforementioned constraints, `TiledCache` has other parameters that can be used to customize values.
+
+The `filepath` parameter can be used to set the location that the cache will be stored at. It defaults to the user's Tiled directory / "http_response_cache.db".
+
+The `ttl` parameter, which stands for "Time to Live", determines how long an entry can be in the cache until it is deemed expired. Once a cached entry is considered expired, the next time that the automated cleanup runs that entry will be removed from the cache. The default value is `None`.
+
+## Streaming
+
+Data may be streamed through the client-side cache. This streaming feature is largely handled through Hishel, however the size of the streamed data is monitored within `TiledCache`. This size management is done through the use of a generator, `_check_max_stream_bytes`. This generator keeps track of the accumulated size as the stream is occurring and will remove the cached entry in the event that the size exceeds the maximum item size. If this happens, the entry is soft-deleted so that the stream may continue to provide data in the response (the only impact would be that the streamed data would not be cached, the stream will not be halted).
+
+## Thread Safety
+
+The client-side cache has methods in place to ensure thread safety through a thread lock to prevent parallel writes.
+
+## Entry Size Constraint Enforcement
+
+The function `measure_entry_size` is used as a pre-check to see if the size of the cached entry exceeds the maximum size of the item given by `max_item_size`. While the more reliable size check comes from `_check_max_stream_bytes`, this check isn't able to measure a chunk's size until it has been actually streamed. This is due to Hishel's lazy streaming method. So, an entry is made into the `entries` SQL table before the size check with `_check_max_stream_bytes` can happen. As a way to prevent an unnecessary write to the `entries` table, `measure_entry_size` is used to measure the size of the response and request based on the `"content-length"` value in their headers (if they exist). Since their existence depends on the server, `"content-length"` may not exist, but if they do then the size can be measured, and if the size is too large the write to `entries` would be avoided.
+
+## Initializing the Database
+
+Ensuring that the database is properly initialized is handled with the `_setup` function in Tiled which sets the `_setup_completed` Boolean variable and the `_initialized` Boolean variable which is used within Hishel. The reason for using both `_initialized` and `_setup_completed` is that the `_setup` function in Tiled also ensures that the proper version of Tiled cache is in use. Also, the `_initialize_database` function that is in Tiled must be run if the database is not initialized in order to add the additional `size` and `time_last_accessed` columns to the SQL table. `_initialized` must remain as well because that is how Hishel determines whether or not the database has been initialized, not with `_setup_completed`. Without it, the database may be attempted to be initialized multiple times.
+
+## Connection Configuration
+
+The connection is configured within Hishel at the initializing database stage. This configuration includes:
+
+(1) `journal_mode` being set to `WAL` (Write-Ahead Logging). This setting allows readers and writers to access the database simultaneously.
+(2) `busy_timeout` being set to `5000`. The units are milliseconds. This is how long a connection will retry when hitting a locked database. After that time is reached, `SQLITE_BUSY` is returned.
+(3) `synchronous` being set to `NORMAL`. This makes it so it syncs at checkpoints (as opposed to every commit).
+(4) `foreign_keys` being set to `ON`. This enables foreign key constraint enforcement to delete the children when the parent with the ID is deleted.
+
+## Function Descriptions
+
+### `create_entry` / `_create_entry`
+
+Used to store an entry in the cache. `create_entry` ensures necessary requirements are present (such as the database being set up) and then calls `_create_entry` to actually store the entry in the cache. `_create_entry` will ensure that the size is within the constraint and enter the entry into the SQL table. It will do LRU eviction in the event the size of all entries in the cache exceeds the capacity of the cache. The function returns an Entry object in addition to writing to the SQL table. If the entry cannot be stored in the SQL table, the function will return a generic Entry object without commiting to the database.
+
+### `get_entries`
+
+The `get_entries` function is used to retrieve a response from the cache based on a provided key. This cache key is passed in as a parameter. The cache keys are set based on the function `_get_key_for_request` found in the `SyncCacheProxy` class of Hishel in `_sync_cache.py`. `get_entries` gathers any entries in the cache that have a key matching with the passed in `key` parameter and return those entries as a list. If there are no entries with a matching `key`, the function returns an empty list. Additionally, the `time_last_accessed` value of the cache entries gathered are updated with the current time in the SQL table as long as the value of `readonly` is false.
+
+### `update_entry`
+
+The `update_entry` function updates the data and cache key of an entry in the SQL table based on passed in parameters. This skips over entries that have an unfinished stream to not disrupt the stream due to it being lazy.
+
+### `clear`
+
+The `clear` function can be used to remove all entries in both the `streams` and `entries` SQL tables.
+
+### `size` and `count` information
+
+The `size` and `count` functions are used to gather information for the cache in terms of the size of all of the cache entries combined and the number of cached entries.
+
+### `_remove_expired_caches`
+
+Once the time that a cached entry has been present in the cache exceeds the set time to live (`ttl`) value the entry would be considered expired and can be removed with the `_remove_expired_caches` function. This uses soft deletion, which is elaborated on in the next section.
+
+## Soft Deletion
+
+The `remove_entry` function from Hishel is used when removing entries from the cache. This soft deletes the cached entry by marking the entry in the table. The entry does not become immediately deleted but instead is deleted after one hour by `_batch_cleanup`. The reason for soft deleting the entries instead of hard (or immediately) deleting the entries is because of the lazy method Hishel uses for handling streaming chunks. By soft deleting, if a stream is still occurring it will have time to finish streaming before the stream gets disrupted when a response is going through to the user. If the entries were to be hard deleted, it would disrupt the stream. After the time passes, all the entries that have been marked with being soft deleted will be removed from the cache.
+
+## TiledTransport
+
+### Overview
+
+The transport that is intended to be used with the cache is `TiledTransport`. A client can be set up with this transport as follows:
+
+```
+tiled_cache = TiledCache()
+
+client = httpx.Client(transport=TiledTransport(cache=tiled_cache))
+```
+
+Further parameters can be set in the `TiledTransport` transport to further customize it, such as with `cacheable_methods` which determines which types of methods (such as `"GET"` or `"POST"`) can be cached. Additionally, the `shared` parameter value can be set, which defaults to `True`. `shared` determines if the cache is meant to serve multiple users (`True`) or if the cache should act as a private cache (`False`). If dealing with authenticated responses, `shared` must be set to `False` or caching will be blocked due to Hishel's usage of RFC 9111 standards.
+
+The transport intercepts requests and checks whether or not the requested data is present in the cache. If the requested data is present in the cache, then the data is provided to the user without having to go further to get the data. If the data is not in the cache, then the data must be retrieved from the server.
+
+### Additional Transport Parameters
+
+A parameter that can be set during the initialization of  `TiledTransport` is `transport`. `transport` determines what base transport is being used, with the defaults being `httpx.HTTPTransport`. Additionally, with a `cache` parameter present, the `transport` is wrapped with `SyncCacheTransport` from Hishel, which allows Hishel's transport to carry out its method for handling requests, and it handles certain activities like writes.
+
+Another parameter that can be set is `limits`. This parameter determines limits for client behaviors, such as the maximum number of concurrent connections.

--- a/docs/source/explanations/client-side-cache.md
+++ b/docs/source/explanations/client-side-cache.md
@@ -117,7 +117,7 @@ tiled_cache = TiledCache()
 client = httpx.Client(transport=TiledTransport(cache=tiled_cache))
 ```
 
-Further parameters can be set in the `TiledTransport` transport to further customize it, such as with `cacheable_methods` which determines which types of methods (such as `"GET"` or `"POST"`) can be cached. Additionally, the `shared` parameter value can be set, which defaults to `True`. `shared` determines if the cache is meant to serve multiple users (`True`) or if the cache should act as a private cache (`False`). If dealing with authenticated responses, `shared` must be set to `False` or caching will be blocked due to Hishel's usage of RFC 9111 standards.
+Further parameters can be set in the `TiledTransport` transport to further customize it, such as with `cacheable_methods` which determines which types of methods (such as `"GET"` or `"POST"`) can be cached. Additionally, the `shared` parameter value can be set, which defaults to `False`. `shared` determines if the cache is meant to serve multiple users (`True`) or if the cache should act as a private cache (`False`). If dealing with authenticated responses, `shared` must be set to `False` or caching will be blocked due to Hishel's usage of RFC 9111 standards.
 
 The transport intercepts requests and checks whether or not the requested data is present in the cache. If the requested data is present in the cache, then the data is provided to the user without having to go further to get the data. If the data is not in the cache, then the data must be retrieved from the server.
 

--- a/docs/source/explanations/client-side-cache.md
+++ b/docs/source/explanations/client-side-cache.md
@@ -97,9 +97,9 @@ The `clear` function can be used to remove all entries in both the `streams` and
 
 The `size` and `count` functions are used to gather information for the cache in terms of the size of all of the cache entries combined and the number of cached entries.
 
-### `_remove_expired_caches`
+## Expired Entries
 
-Once the time that a cached entry has been present in the cache exceeds the set time to live (`default_ttl`) value the entry would be considered expired and can be removed with the `_remove_expired_caches` function. This uses soft deletion, which is elaborated on in the next section.
+Once the time that a cached entry has been present in the cache exceeds the set time to live (`default_ttl` or the metadata `"hishel_ttl"`) value the entry would be considered expired. The next time `_batch_cleanup` on Hishel occurs, the entry will be deleted. 
 
 ## Soft Deletion
 

--- a/tests/test_client_cache.py
+++ b/tests/test_client_cache.py
@@ -225,3 +225,16 @@ async def test_thread_lock():
         run_time = time.perf_counter() - t0
     # Check that the threads didn't run in parallel
     assert run_time >= (2.0 * timer.sleep_time), "Threads did not lock"
+
+
+def test_remove_expired_caches(client):
+    cache = client.context.cache
+    client.context.cache.default_ttl = 1
+    with record_history() as h:
+        client.values()[0]
+    for response in h.responses:
+        assert cache.count() > 0
+
+    time.sleep(1)
+    client.context.cache._remove_expired_caches()
+    assert cache.count() == 0

--- a/tests/test_client_cache.py
+++ b/tests/test_client_cache.py
@@ -39,7 +39,6 @@ def test_cache(client, tmpdir):
     # First time: not cached
     with record_history() as h:
         list(client.keys())
-        print(h.responses)
     for response in h.responses:
         assert not response.extensions.get("hishel_from_cache")
 

--- a/tests/test_client_cache.py
+++ b/tests/test_client_cache.py
@@ -230,11 +230,7 @@ async def test_thread_lock():
 def test_remove_expired_caches(client):
     cache = client.context.cache
     client.context.cache.default_ttl = 1
-    with record_history() as h:
-        client.values()[0]
-    for response in h.responses:
-        assert cache.count() > 0
-
+    assert cache.count() > 0
     time.sleep(1)
     client.context.cache._remove_expired_caches()
     assert cache.count() == 0

--- a/tests/test_client_cache.py
+++ b/tests/test_client_cache.py
@@ -11,7 +11,7 @@ import pytest
 from tiled.adapters.array import ArrayAdapter
 from tiled.adapters.mapping import MapAdapter
 from tiled.client import Context, from_context, record_history
-from tiled.client.cache import Cache, CachedResponse, ThreadingMode, with_thread_lock
+from tiled.client.cache import ThreadingMode, TiledCache, with_thread_lock
 from tiled.server.app import build_app
 
 tree = MapAdapter(
@@ -26,20 +26,22 @@ tree = MapAdapter(
 @pytest.fixture
 def client():
     app = build_app(tree)
-    with Context.from_app(app, cache=Cache()) as context:
+    with Context.from_app(app, cache=TiledCache()) as context:
         yield from_context(context)
 
 
 def test_cache(client, tmpdir):
+    # assert False
     cache = client.context.cache
+
     before_count = cache.count()
     before_size = cache.size()
-
     # First time: not cached
     with record_history() as h:
         list(client.keys())
+        print(h.responses)
     for response in h.responses:
-        assert not isinstance(response, CachedResponse)
+        assert not response.extensions.get("hishel_from_cache")
 
     after_count = cache.count()
     after_size = cache.size()
@@ -50,7 +52,7 @@ def test_cache(client, tmpdir):
     with record_history() as h:
         list(client.keys())
     for response in h.responses:
-        assert isinstance(response, CachedResponse)
+        assert response.extensions.get("hishel_from_cache")
 
 
 def test_no_cache(client):
@@ -60,17 +62,18 @@ def test_no_cache(client):
     with record_history() as h:
         list(client.keys())
     for response in h.responses:
-        assert not isinstance(response, CachedResponse)
+        assert not response.extensions.get("hishel_from_cache")
 
     # Second time: cached
     with record_history() as h:
         list(client.keys())
     for response in h.responses:
-        assert not isinstance(response, CachedResponse)
+        assert not response.extensions.get("hishel_from_cache")
 
 
 def test_lru_eviction(client):
     # First time: not cached
+    client.context.cache.max_item_size = 1000
     client.context.cache.capacity = 5000
     num_items = len(client)
     for i in range(num_items):
@@ -85,19 +88,19 @@ def test_lru_eviction(client):
     with record_history() as h:
         client.values()[i]
     for response in h.responses:
-        assert isinstance(response, CachedResponse)
+        assert response.extensions.get("hishel_from_cache")
 
     # Least recently accessed: has been evicted
     with record_history() as h:
         client.values()[0]
     for response in h.responses:
-        assert not isinstance(response, CachedResponse)
+        assert not response.extensions.get("hishel_from_cache")
 
     # Second time: cached
     with record_history() as h:
         client.metadata
     for response in h.responses:
-        assert not isinstance(response, CachedResponse)
+        assert not response.extensions.get("hishel_from_cache")
 
 
 def test_item_too_large_to_store(client):
@@ -107,13 +110,13 @@ def test_item_too_large_to_store(client):
     with record_history() as h:
         list(client.keys())
     for response in h.responses:
-        assert not isinstance(response, CachedResponse)
+        assert not response.extensions.get("hishel_from_cache")
 
     # Second time: still not cached
     with record_history() as h:
         list(client.keys())
     for response in h.responses:
-        assert not isinstance(response, CachedResponse)
+        assert not response.extensions.get("hishel_from_cache")
 
 
 def test_readonly_cache(client):
@@ -123,38 +126,38 @@ def test_readonly_cache(client):
     with record_history() as h:
         client.values()[0]
     for response in h.responses:
-        assert not isinstance(response, CachedResponse)
+        assert not response.extensions.get("hishel_from_cache")
 
     # Second time: cached
     with record_history() as h:
         client.values()[0]
     for response in h.responses:
-        assert isinstance(response, CachedResponse)
+        assert response.extensions.get("hishel_from_cache")
 
     orig_size = client.context.cache.size()
 
     # Now use the same file as readonly cache.
     filepath = client.context.cache.filepath
-    ro_cache = client.context.cache = Cache(filepath, readonly=True)
+    ro_cache = client.context.cache = TiledCache(filepath=filepath, readonly=True)
 
     # Still cached (from before)
     with record_history() as h:
         client.values()[0]
     for response in h.responses:
-        assert isinstance(response, CachedResponse)
+        assert response.extensions.get("hishel_from_cache")
 
     # Now look at something new...
     # First time: not cached
     with record_history() as h:
         client.values()[1]
     for response in h.responses:
-        assert not isinstance(response, CachedResponse)
+        assert not response.extensions.get("hishel_from_cache")
 
     # Second time: still not cached
     with record_history() as h:
         client.values()[1]
     for response in h.responses:
-        assert not isinstance(response, CachedResponse)
+        assert not response.extensions.get("hishel_from_cache")
 
     # And cache size has not changed
     assert ro_cache.size() == orig_size
@@ -162,7 +165,7 @@ def test_readonly_cache(client):
     # Implementation detail: database connection is read-only,
     # for defense in depth.
     with pytest.raises(sqlite3.OperationalError):
-        with closing(ro_cache._conn.cursor()) as cur:
+        with closing(ro_cache.connection.cursor()) as cur:
             cur.execute("DELETE FROM responses")
 
 
@@ -186,10 +189,10 @@ def test_not_thread_safe(client, monkeypatch):
             future.result(timeout=1)
 
 
-@pytest.mark.skipif(
-    sqlite3.threadsafety != ThreadingMode.SERIALIZED,
-    reason="sqlite not built with thread safe support",
-)
+# @pytest.mark.skipif(
+#     sqlite3.threadsafety != ThreadingMode.SERIALIZED,
+#     reason="sqlite not built with thread safe support",
+# )
 def test_thread_safety(client):
     cache = client.context.cache
     # Clear the cache in another thread

--- a/tiled/client/cache.py
+++ b/tiled/client/cache.py
@@ -69,13 +69,13 @@ class TiledCache(SyncSqliteStorage):
         self,
         *,
         connection: tp.Optional[sqlite3.Connection] = None,
-        ttl: tp.Optional[tp.Union[int, float]] = None,
+        default_ttl: tp.Optional[tp.Union[int, float]] = None,
         filepath=None,
         capacity=500_000_000,
         max_item_size=500_000,
         readonly=False,
     ) -> None:
-        # ttl is in seconds, capacity and max_item_size are in bytes
+        # default_ttl is in seconds, capacity and max_item_size are in bytes
 
         self._setup_completed: bool = False
 
@@ -96,8 +96,11 @@ class TiledCache(SyncSqliteStorage):
         self.max_item_size = max_item_size
         self._readonly = readonly
         self._owner_thread = threading.current_thread().ident
+        self.default_ttl = default_ttl
 
-        super().__init__(connection=connection, database_path=filepath, default_ttl=ttl)
+        super().__init__(
+            connection=connection, database_path=filepath, default_ttl=default_ttl
+        )
 
         self._setup()
 

--- a/tiled/client/cache.py
+++ b/tiled/client/cache.py
@@ -1,151 +1,25 @@
 import enum
-import json
 import os
 import sqlite3
+import sys
 import threading
 import typing as tp
+import uuid
 from contextlib import closing
 from datetime import datetime
 from functools import wraps
 from pathlib import Path
 
-import httpx
 import platformdirs
+from hishel import Entry, EntryMeta, SyncSqliteStorage
+from httpcore import Request, Response
 
-from .utils import SerializableLock, TiledResponse
+from .logger import logger
 
-CACHE_DATABASE_SCHEMA_VERSION = 1
+CACHE_DATABASE_SCHEMA_VERSION = 2
 
-
-class CachedResponse(TiledResponse):
-    pass
-
-
-def get_cache_key(request: httpx.Request) -> str:
-    """Get the cache key from a request.
-
-    The cache key is the str request url.
-
-    Args:
-        request: httpx.Request
-
-    Returns:
-        str: httpx.Request.url
-    """
-    return str(request.url)
-
-
-def get_size(response, content=None):
-    # get content or stream_content
-    if hasattr(response, "_content"):
-        size = len(response.content)
-    elif content is None:
-        raise httpx.ResponseNotRead()
-    else:
-        size = len(content)
-    return size
-
-
-def dump(response, content=None):
-    # get content or stream_content
-    if hasattr(response, "_content"):
-        body = response.content
-        is_stream = False
-    elif content is None:
-        raise httpx.ResponseNotRead()
-    else:
-        body = content
-        is_stream = True
-
-    return (
-        response.status_code,
-        json.dumps(response.headers.multi_items()),
-        body,
-        is_stream,
-        response.encoding or None,
-        len(body),
-        datetime.now().timestamp(),
-        0,  # never yet accessed
-    )
-
-
-def load(row, request=None):
-    status_code, headers_json, body, is_stream, encoding = row
-    headers = json.loads(headers_json)
-    if is_stream:
-        content = None
-        stream = httpx.ByteStream(body)
-    else:
-        content = body
-        stream = None
-    response = CachedResponse(
-        status_code, headers=headers, content=content, stream=stream
-    )
-    if encoding is not None:
-        response.encoding = encoding
-
-    if request is not None:
-        response.request = request
-    return response
-
-
-def _create_tables(conn):
-    with closing(conn.cursor()) as cur:
-        cur.execute(
-            """CREATE TABLE responses (
-cache_key TEXT PRIMARY KEY,
-status_code INTEGER,
-headers JSON,
-body BLOB,
-is_stream INTEGER,
-encoding TEXT,
-size INTEGER,
-time_created REAL,
-time_last_accessed REAL
-)"""
-        )
-        cur.execute("CREATE TABLE tiled_http_response_cache_version (version INTEGER)")
-        cur.execute(
-            "INSERT INTO tiled_http_response_cache_version (version) VALUES (?)",
-            (CACHE_DATABASE_SCHEMA_VERSION,),
-        )
-        conn.commit()
-
-
-def _prepare_database(filepath, readonly):
-    Path(filepath).parent.mkdir(parents=True, exist_ok=True)
-    if readonly:
-        # The methods in Cache will not try to write when in readonly mode.
-        # For extra safety we open a readonly connection to the database, so
-        # that SQLite itself will prohibit writing.
-        conn = sqlite3.connect(
-            f"file:{filepath}?mode=ro", uri=True, check_same_thread=False
-        )
-    else:
-        conn = sqlite3.connect(filepath, check_same_thread=False)
-    cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table';")
-    tables = [row[0] for row in cursor.fetchall()]
-    if not tables:
-        # We have an empty database.
-        _create_tables(conn)
-    elif "tiled_http_response_cache_version" not in tables:
-        # We have a nonempty database that we do not recognize.
-        raise RuntimeError(
-            f"Database at {filepath} is not empty and not recognized as a tiled HTTP response cache."
-        )
-    else:
-        # We have a nonempty database that we recognize.
-        cursor = conn.execute("SELECT * FROM tiled_http_response_cache_version;")
-        (version,) = cursor.fetchone()
-        if version != CACHE_DATABASE_SCHEMA_VERSION:
-            # It is likely that this cache database will be very stable; we
-            # *may* never need to change the schema. But if we do, we will
-            # not bother with migrations. The cache is highly disposable.
-            # Just silently blow it away and start over.
-            Path(filepath).unlink()
-            conn = sqlite3.connect(filepath, check_same_thread=False)
-            _create_tables(conn)
-    return conn
+# This is currently only used for checking SQlite thread-safety
+PY311 = sys.version_info >= (3, 11)
 
 
 def with_thread_lock(fn):
@@ -175,35 +49,57 @@ class ThreadingMode(enum.IntEnum):
     SERIALIZED = 3
 
 
-class Cache:
+def measure_entry_size(request, response):
+    # httpcore exception that is == httpx.ResponseNotRead()
+    # Trace out the way this works for a streaming response
+    # Also handle streaming request
+    size = 0
+
+    if hasattr(response, "headers") and "content-length" in response.headers:
+        size += int(response.headers["content-length"])
+
+    if hasattr(request, "headers") and "content-length" in request.headers:
+        size += int(request.headers["content-length"])
+
+    return size
+
+
+class TiledCache(SyncSqliteStorage):
     def __init__(
         self,
+        *,
+        connection: tp.Optional[sqlite3.Connection] = None,
+        ttl: tp.Optional[tp.Union[int, float]] = None,
         filepath=None,
         capacity=500_000_000,
         max_item_size=500_000,
         readonly=False,
-    ):
+    ) -> None:
+        # ttl is in seconds, capacity and max_item_size are in bytes
+
+        self._setup_completed: bool = False
+
         if filepath is None:
             # Resolve this here, not at module scope, because the test suite
             # injects TILED_CACHE_DIR env var to use a temporary directory.
             TILED_CACHE_DIR = Path(
                 os.getenv("TILED_CACHE_DIR", platformdirs.user_cache_dir("tiled"))
             )
-            # TODO Detect filesystem of TILED_CACHE_DIR. If it is a networked filesystem
-            # use a temporary database instead.
+            # TODO Consider defaulting to a temporary database, with a warning,
+            # if TILED_CACHE_DIR points to a networked filesystem. Unless perhaps
+            # flock() support can be checked (nfs version, or lock manager, etc).
             filepath = TILED_CACHE_DIR / "http_response_cache.db"
-        if capacity <= max_item_size:
-            raise ValueError("capacity must be greater than max_item_size")
-        self._capacity = capacity
-        self._max_item_size = max_item_size
-        self._readonly = readonly
         self._filepath = filepath
+        self._capacity = None
+        self._max_item_size = None
+        self.capacity = capacity
+        self.max_item_size = max_item_size
+        self._readonly = readonly
         self._owner_thread = threading.current_thread().ident
-        self._conn = _prepare_database(filepath, readonly)
-        self._lock = SerializableLock()
 
-    def __repr__(self):
-        return f"<{type(self).__name__} {str(self._filepath)!r}>"
+        super().__init__(connection=connection, database_path=filepath, default_ttl=ttl)
+
+        self._setup()
 
     def write_safe(self):
         """Check that it is safe to write.
@@ -218,183 +114,444 @@ class Cache:
         sqlite_is_safe = sqlite3.threadsafety == ThreadingMode.SERIALIZED
         return is_main_thread or sqlite_is_safe
 
+    def _setup(self) -> None:
+        if not self._setup_completed:
+            if not self.connection:
+                # The methods in the Cache storage object will not try to write when
+                # in readonly mode. For extra safety, we open a readonly connection
+                # to the database, so that SQLite itself will prohibit writing.
+                database = (
+                    f"file:{self._filepath}?mode=ro"
+                    if self._readonly
+                    else self._filepath
+                )
+                self.connection = sqlite3.connect(
+                    database, uri=self._readonly, check_same_thread=False
+                )
+            cursor = self.connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='table';"
+            )
+            tables = [row[0] for row in cursor.fetchall()]
+            if not tables:
+                # We have an empty database
+                self._initialize_database()
+
+            elif "tiled_http_response_cache_version" not in tables:
+                # We have a non-empty database that we do not recognize.
+                raise RuntimeError(
+                    f"Database at {self._filepath} is not empty and is not "
+                    f"recognized as a Tiled HTTP response cache."
+                )
+            else:
+                # We have a non-empty database that we recognize.
+                cursor = self.connection.execute(
+                    "SELECT * FROM tiled_http_response_cache_version;"
+                )
+                (version,) = cursor.fetchone()
+                if version != CACHE_DATABASE_SCHEMA_VERSION:
+                    # It is likely that this cache database will be very stable,
+                    # but if we must make changes we will not bother with migrations.
+                    # The cache is highly disposable. Just silently blow it away and start over.
+                    Path(self._filepath).unlink()
+                    self.connection = sqlite3.connect(
+                        self._filepath, check_same_thread=False
+                    )
+                    self._initialize_database()
+
+            cursor.close()
+            self._initialized = True
+            self._setup_completed = True
+
+    def _initialize_database(self) -> None:
+        super()._initialize_database()
+        with self._lock, closing(self.connection.cursor()) as cursor:
+            cursor.execute("ALTER TABLE entries ADD COLUMN size INTEGER")
+            cursor.execute("ALTER TABLE entries ADD COLUMN time_last_accessed INTEGER")
+
+            cursor.execute(
+                "CREATE TABLE tiled_http_response_cache_version (version INTEGER)"
+            )
+            cursor.execute(
+                "INSERT INTO tiled_http_response_cache_version (version) VALUES (?)",
+                (CACHE_DATABASE_SCHEMA_VERSION,),
+            )
+
+            self.connection.commit()
+
+    def __repr__(self):
+        module = type(self).__module__
+        qualname = type(self).__qualname__
+        memaddress = hex(id(self))
+        dbfile = str(self.filepath)
+        return f"<{module}.{qualname} object at {memaddress} using database {dbfile!r}>"
+
     def __getstate__(self):
         return (
-            self.filepath,
-            self.capacity,
-            self.max_item_size,
-            self._readonly,
+            self._setup_completed,
             self._lock,
+            self._filepath,
+            self._capacity,
+            self._max_item_size,
+            self._readonly,
         )
 
     def __setstate__(self, state):
-        (filepath, capacity, max_item_size, readonly, lock) = state
+        (setup_completed, lock, filepath, capacity, max_item_size, readonly) = state
+        self._lock = lock
+        self._filepath = filepath
         self._capacity = capacity
         self._max_item_size = max_item_size
         self._readonly = readonly
-        self._filepath = filepath
-        self._owner_thread = threading.current_thread().ident
-        self._conn = _prepare_database(filepath, readonly)
-        self._lock = lock
-
-    @property
-    def readonly(self):
-        "If True, cache be read but not updated."
-        return self._readonly
+        if setup_completed:
+            self._setup()
 
     @property
     def filepath(self):
-        "Filepath of SQLite database storing cache data"
+        """Filepath of the SQLite database used for storing cache data"""
         return self._filepath
 
     @property
     def capacity(self):
-        "Max capacity in bytes. Includes response bodies only."
+        """Max capacity of the cache, in bytes. Includes the response AND request bodies."""
         return self._capacity
 
     @capacity.setter
     def capacity(self, capacity):
+        if capacity < 1:
+            raise ValueError("Cache capacity cannot be less than 1 byte")
+        elif self._max_item_size and capacity < self._max_item_size:
+            raise ValueError("Cache capacity cannot be less than allowed entry size")
         self._capacity = capacity
 
     @property
     def max_item_size(self):
-        "Max size of a response body eligible for caching."
+        """
+        Max size of a response body that can be accepted into the cache.
+        The size of the request body will be included against this limit.
+        """
         return self._max_item_size
 
     @max_item_size.setter
     def max_item_size(self, max_item_size):
+        if max_item_size < 1:
+            raise ValueError("Cache entry size cannot be less than 1 byte")
+        elif max_item_size > self.capacity:
+            raise ValueError("Cache entry size cannot be greater than cache capacity")
         self._max_item_size = max_item_size
+
+    @property
+    def readonly(self):
+        """If readonly, cache can be read but not updated."""
+        return self._readonly
+
+    def _create_entry(
+        self,
+        request: Request,
+        response: Response,
+        key: str,
+        id_: uuid.UUID | None = None,
+    ) -> Entry:
+        """
+        Store an entry in the cache.
+
+        :param request: An HTTP request
+        :type request: httpcore.Request
+        :param response: An HTTP response
+        :type response: httpcore.Response
+        :param key: The key which identifies the entry in the cache
+        :type key: str
+        :param id_: The UUID identifying the entry
+        :type id_: UUID
+
+        """
+        if self.connection is None or not self._setup_completed:
+            raise RuntimeError("Cache is not connected")
+        if not self.write_safe():
+            raise RuntimeError("Write is not safe from another thread")
+        if self.readonly:
+            # Returns an Entry that is not commited to the database or streamed.
+            return Entry(
+                id=id_ or uuid.uuid4(),
+                request=request,
+                response=response,
+                meta=EntryMeta(created_at=datetime.now().timestamp()),
+                cache_key=key.encode("utf-8"),
+            )
+        with self._lock, closing(self.connection.cursor()) as cursor:
+            # This is an intial check to see if the response/request are too large to cache as an entry
+            request_and_response_size = measure_entry_size(request, response)
+            if request_and_response_size > self.max_item_size:
+                logger.debug(
+                    f"Cache declined entry which is too large: "
+                    f"{request_and_response_size} > {self.max_item_size} (bytes)"
+                )
+                # Like in the readonly branch, returns an Entry that is not commited to the database or streamed.
+                return Entry(
+                    id=id_ or uuid.uuid4(),
+                    request=request,
+                    response=response,
+                    meta=EntryMeta(created_at=datetime.now().timestamp()),
+                    cache_key=key.encode("utf-8"),
+                )
+
+            # Below commits to the database in the parent and handles the stream table
+            parent_entry = super().create_entry(
+                request=request, response=response, key=key, id_=id_
+            )
+
+            # 8 bytes in a REAL, and max 8 bytes for INTEGER so +8 for size and created_at and time_last_accessed
+            starting_size = (
+                len(parent_entry.cache_key) + len(parent_entry.id.bytes) + 24
+            )
+            if parent_entry.meta.deleted_at:
+                starting_size += 8
+
+            cursor.execute(
+                "UPDATE entries SET size = ?, time_last_accessed = ? WHERE id = ?",
+                (
+                    request_and_response_size + starting_size,
+                    datetime.now().timestamp(),
+                    parent_entry.id.bytes,
+                ),
+            )
+
+            # This accumulated_size_state was made into a dict so that both request and response can
+            # access it and so we know if the event where the size exceeds the maximum was handles already so
+            # that logic doesn't keep running as the stream finishes out.
+            accumulated_size_state = {"size": starting_size, "exceed_handled": False}
+            parent_entry.request.stream = self._check_max_stream_bytes(
+                parent_entry.id, parent_entry.request.stream, accumulated_size_state
+            )
+            parent_entry.response.stream = self._check_max_stream_bytes(
+                parent_entry.id, parent_entry.response.stream, accumulated_size_state
+            )
+
+            entry = Entry(
+                id=parent_entry.id,
+                request=parent_entry.request,
+                response=parent_entry.response,
+                meta=parent_entry.meta,
+                cache_key=parent_entry.cache_key,
+            )
+
+            (total_size,) = cursor.execute(
+                "SELECT SUM(size) FROM entries WHERE deleted_at is NULL"
+            ).fetchone()
+            total_size = total_size or 0  # If empty, total_size is None
+
+            # This is the LRU eviction.
+            while (total_size) > self.capacity:
+                (entry_id, size) = cursor.execute(
+                    """SELECT id, size FROM entries WHERE deleted_at is NULL ORDER BY time_last_accessed ASC"""
+                ).fetchone()
+
+                # remove_entry is to soft delete in case stream is still being read.
+                # Corresponding stream entries will be deleted at cleanup.
+                self.remove_entry(uuid.UUID(bytes=entry_id))
+                total_size -= size
+
+            self.connection.commit()
+
+            return entry
+
+    @with_thread_lock
+    def create_entry(
+        self,
+        request: Request,
+        response: Response,
+        key: str,
+        id_: uuid.UUID | None = None,
+    ) -> Entry:
+        if not self._setup_completed:
+            self._setup()
+        entries = self.get_entries(key=key)
+        if not entries:
+            # Prevents any possibility of there being multiple entries on a cache hit.
+            entry = self._create_entry(request, response, key, id_)
+        else:
+            return entries[0]
+        if entry is not None:
+            self._remove_expired_caches()
+        return entry
+
+    # Generator to keep track of how many bytes were streamed to ensure
+    # entry remains under the max entry size for the cache.
+    # If the entry exceeds, it is deleted from the cache but the stream continues.
+    # The partial entry in streams is also deleted from the streams table
+    def _check_max_stream_bytes(
+        self, entry_id, stream_iterator, accumulated_size_state
+    ):
+        for chunk in stream_iterator:
+            accumulated_size_state["size"] += len(chunk)
+            if not accumulated_size_state["exceed_handled"]:
+                # Below deletes the entry when too large
+                if accumulated_size_state["size"] > self.max_item_size:
+                    accumulated_size_state["exceed_handled"] = True
+                    self.remove_entry(entry_id)  # This soft deletes for the entry table
+                    logger.debug(
+                        f"Cache declined entry which is too large with stream: > {self.max_item_size} (bytes)"
+                    )
+                else:
+                    with self._lock, closing(self.connection.cursor()) as cursor:
+                        cursor.execute(
+                            "UPDATE entries SET size = ?, time_last_accessed = ? WHERE id = ?",
+                            (
+                                accumulated_size_state["size"],
+                                datetime.now().timestamp(),
+                                entry_id.bytes,
+                            ),
+                        )
+
+                        self.connection.commit()
+
+                        # This is the LRU eviction.
+                        (total_size,) = cursor.execute(
+                            "SELECT SUM(size) FROM entries WHERE deleted_at is NULL"
+                        ).fetchone()
+                        total_size = total_size or 0  # If empty, total_size is None
+
+                        while (total_size) > self.capacity:
+                            (entry_id, size) = cursor.execute(
+                                """SELECT id, size FROM entries WHERE deleted_at
+                                is NULL ORDER BY time_last_accessed ASC"""
+                            ).fetchone()
+                            self.remove_entry(
+                                uuid.UUID(bytes=entry_id)
+                            )  # This is to soft delete in case stream is still being read
+                            total_size -= size
+            yield chunk
+
+            if accumulated_size_state["exceed_handled"]:
+                # This deletes from streams after generator finishes. Does this after
+                # the generator finishes because chunks are written lazily
+                with self._lock, closing(self.connection.cursor()) as cursor:
+                    cursor.execute(
+                        "DELETE FROM streams WHERE entry_id = ?",
+                        (entry_id.bytes,),
+                    )
+                    self.connection.commit()
+
+    @with_thread_lock
+    def get_entries(self, key: str) -> tp.List[Entry]:
+        """
+        Retreive a response from the cache according to the provided key.
+
+        :param key: The key which identifies the entry in the cache
+        :type key: str
+        :return: A list of cached entries.
+        :rtype: tp.List[Entry]
+        """
+        if not self._setup_completed:
+            self._setup()
+
+        parent_entries = super().get_entries(key=key)
+
+        if not parent_entries:
+            # Cache miss
+            return []
+
+        with self._lock, closing(self.connection.cursor()) as cursor:
+            entries = []
+            for entry in parent_entries:
+                updated_entry = Entry(
+                    id=entry.id,
+                    request=entry.request,
+                    meta=entry.meta,
+                    response=entry.response,
+                    cache_key=entry.cache_key,
+                )
+                entries.append(updated_entry)
+                if not self.readonly and self.write_safe():
+                    cursor.execute(
+                        "UPDATE entries SET time_last_accessed = ? WHERE id = ?",
+                        (datetime.now().timestamp(), entry.id.bytes),
+                    )
+                    self.connection.commit()
+            return entries
+
+    def update_entry(
+        self,
+        id: uuid.UUID,
+        new_entry: tp.Union[Entry, tp.Callable[[Entry], Entry]],
+    ) -> tp.Optional[Entry]:
+        """
+        Updates the Entry of the stored data.
+
+        :param id: The UUID which identifies the entry in the cache
+        :type id: UUID
+        :param new_entry: The new Entry that we will be updating to.
+        :type new_entry: tp.Union[Entry, tp.Callable[[Entry], Entry]]
+
+        """
+        if self.connection is None or not self._setup_completed:
+            raise RuntimeError("Cache is not connected")
+        if not self.readonly:
+            completed_entry = super().update_entry(id=id, new_pair=new_entry)
+            with self._lock:
+                connection = self._ensure_connection()
+                cursor = connection.cursor()
+                cursor.execute(
+                    "UPDATE entries SET time_last_accessed = ? WHERE id = ?",
+                    (
+                        datetime.now().timestamp(),
+                        id.bytes,
+                    ),
+                )
+                connection.commit()
+                cursor.close()
+
+            return completed_entry
+
+    def _remove_expired_caches(self) -> None:
+        """Remove all expired entries from the cache."""
+        if self.connection is None or not self._setup_completed:
+            raise RuntimeError("Cache is not connected")
+        if self.readonly or self.default_ttl is None:
+            return
+        with self._lock, closing(self.connection.cursor()) as cursor:
+            entry_ids = cursor.execute(
+                "SELECT id FROM entries WHERE created_at + ? < ?",
+                [self.default_ttl, datetime.now().timestamp()],
+            ).fetchall()
+            for (entry_id,) in entry_ids:
+                self.remove_entry(uuid.UUID(bytes=entry_id))
 
     @with_thread_lock
     def clear(self):
-        """
-        Drop all entries from HTTP response cache.
-        """
+        """Drop all entries from HTTP response cache."""
+        if self.connection is None or not self._setup_completed:
+            raise RuntimeError("Cache is not connected")
         if self.readonly:
             raise RuntimeError("Cannot clear read-only cache")
         if not self.write_safe():
             raise RuntimeError(
                 "Cannot clear cache from a different thread than the one it was created on"
             )
-        with closing(self._conn.cursor()) as cur:
-            cur.execute("DELETE FROM responses")
-            self._conn.commit()
-
-    @with_thread_lock
-    def get(self, request: httpx.Request) -> tp.Optional[httpx.Response]:
-        """Get cached response from Cache.
-
-        We use the httpx.Request.url as key.
-
-        Args:
-            request: httpx.Request
-
-        Returns:
-            tp.Optional[httpx.Response]
-        """
-        with closing(self._conn.cursor()) as cur:
-            cache_key = get_cache_key(request)
-            row = cur.execute(
-                """SELECT
-status_code, headers, body, is_stream, encoding
-FROM
-responses
-WHERE cache_key = ?""",
-                (cache_key,),
-            ).fetchone()
-            if row is None:
-                return None
-            if (not self.readonly) and self.write_safe():
-                cur.execute(
-                    """UPDATE responses
-    SET time_last_accessed = ?
-    WHERE cache_key = ?""",
-                    (datetime.now().timestamp(), cache_key),
-                )
-            self._conn.commit()
-
-        return load(row, request)
-
-    @with_thread_lock
-    def set(
-        self,
-        *,
-        request: httpx.Request,
-        response: httpx.Response,
-        content: tp.Optional[bytes] = None,
-    ) -> None:
-        """Set new response entry in cache.
-
-        In case the response does not yet have a '_content' property, content should
-        be provided in the optional 'content' kwarg (usually using a callback)
-
-        Parameters
-        ----------
-        request: httpx.Request
-        response: httpx.Response, to cache
-        content (bytes, optional): Defaults to None, should be provided in case
-            response that not have yet content.
-        """
-        if self.readonly:
-            raise RuntimeError("Cache is readonly")
-        if not self.write_safe():
-            raise RuntimeError("Write is not safe from another thread")
-        incoming_size = get_size(response, content)
-        if incoming_size > self.max_item_size:
-            # Decline to store.
-            return False
-        with closing(self._conn.cursor()) as cur:
-            (total_size,) = cur.execute("SELECT SUM(size) FROM responses").fetchone()
-            total_size = total_size or 0  # If empty, total_size is None.
-            while (incoming_size + total_size) > self.capacity:
-                # Cull to make space.
-                (cache_key, size) = cur.execute(
-                    """SELECT
-cache_key, size
-FROM responses
-ORDER BY time_last_accessed ASC"""
-                ).fetchone()
-                cur.execute("DELETE FROM responses WHERE cache_key = ?", (cache_key,))
-                total_size -= size
-            cur.execute(
-                """INSERT OR REPLACE INTO responses
-(cache_key, status_code, headers, body, is_stream, encoding, size, time_created, time_last_accessed)
-VALUES
-(?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (get_cache_key(request),) + dump(response, content),
-            )
-            self._conn.commit()
-        return True
-
-    @with_thread_lock
-    def delete(self, request: httpx.Request) -> None:
-        """Delete an entry from cache.
-
-        Args:
-            request: httpx.Request
-        """
-        if self.readonly:
-            raise RuntimeError("Cache is readonly")
-        if not self.write_safe():
-            raise RuntimeError("Write is not safe from another thread")
-        with closing(self._conn.cursor()) as cur:
-            cur.execute(
-                "DELETE FROM responses WHERE cache_key=?", (get_cache_key(request),)
-            )
-            self._conn.commit()
+        with self._lock, closing(self.connection.cursor()) as cursor:
+            cursor.execute("DELETE FROM streams")
+            cursor.execute("DELETE FROM entries")
+            self.connection.commit()
 
     def size(self):
-        "Size of response bodies in bytes (does not count headers and other auxiliary info)"
-        with closing(self._conn.cursor()) as cur:
-            (total_size,) = cur.execute("SELECT SUM(size) FROM responses").fetchone()
-        return total_size or 0  # If emtpy, total_size is None.
+        """
+        Size of response bodies in cache in bytes.
+        Includes the size of the corresponding request bodies.
+        Does not include the size of headers and other auxiliary info.
+        """
+        if self.connection is None or not self._setup_completed:
+            raise RuntimeError("Cache is not connected")
+        with self._lock, closing(self.connection.cursor()) as cursor:
+            (total_size,) = cursor.execute(
+                "SELECT SUM(size) FROM entries WHERE deleted_at is NULL"
+            ).fetchone()
+        return total_size or 0  # if empty, total_size is None
 
     def count(self):
-        "Number of responses cached"
-        with closing(self._conn.cursor()) as cur:
-            (count,) = cur.execute("SELECT COUNT(*) FROM responses").fetchone()
-        return count or 0  # If empty, count is None.
-
-    def close(self) -> None:
-        """Close cache."""
-        self._conn.close()
+        """Number of responses cached."""
+        if self.connection is None or not self._setup_completed:
+            raise RuntimeError("Cache is not connected")
+        with self._lock, closing(self.connection.cursor()) as cursor:
+            (count,) = cursor.execute(
+                "SELECT COUNT(*) FROM entries WHERE deleted_at is NULL"
+            ).fetchone()
+        return count or 0  # if empty, count is None

--- a/tiled/client/cache.py
+++ b/tiled/client/cache.py
@@ -5,6 +5,7 @@ import sys
 import threading
 import typing as tp
 import uuid
+import warnings
 from contextlib import closing
 from datetime import datetime
 from functools import wraps
@@ -367,14 +368,7 @@ class TiledCache(SyncSqliteStorage):
     ) -> Entry:
         if not self._setup_completed:
             self._setup()
-        entries = self.get_entries(key=key)
-        if not entries:
-            # Prevents any possibility of there being multiple entries on a cache hit.
-            entry = self._create_entry(request, response, key, id_)
-        else:
-            return entries[0]
-        if entry is not None:
-            self._remove_expired_caches()
+        entry = self._create_entry(request, response, key, id_)
         return entry
 
     # Generator to keep track of how many bytes were streamed to ensure
@@ -414,6 +408,7 @@ class TiledCache(SyncSqliteStorage):
                         total_size = total_size or 0  # If empty, total_size is None
 
                         while (total_size) > self.capacity:
+                            warnings.warn("Stream cannot be cached due to size.")
                             (entry_id, size) = cursor.execute(
                                 """SELECT id, size FROM entries WHERE deleted_at
                                 is NULL ORDER BY time_last_accessed ASC"""
@@ -490,34 +485,52 @@ class TiledCache(SyncSqliteStorage):
             raise RuntimeError("Cache is not connected")
         if not self.readonly:
             completed_entry = super().update_entry(id=id, new_pair=new_entry)
-            with self._lock:
-                connection = self._ensure_connection()
-                cursor = connection.cursor()
-                cursor.execute(
-                    "UPDATE entries SET time_last_accessed = ? WHERE id = ?",
-                    (
-                        datetime.now().timestamp(),
-                        id.bytes,
-                    ),
-                )
-                connection.commit()
-                cursor.close()
+            if completed_entry:
+                with self._lock:
+                    connection = self._ensure_connection()
+                    cursor = connection.cursor()
 
-            return completed_entry
+                    # 8 bytes in a REAL, and max 8 bytes for INTEGER so +8 for size
+                    # and created_at and time_last_accessed
+                    starting_size = (
+                        len(completed_entry.cache_key)
+                        + len(completed_entry.id.bytes)
+                        + 24
+                    )
+                    if completed_entry.meta.deleted_at:
+                        starting_size += 8
 
-    def _remove_expired_caches(self) -> None:
-        """Remove all expired entries from the cache."""
-        if self.connection is None or not self._setup_completed:
-            raise RuntimeError("Cache is not connected")
-        if self.readonly or self.default_ttl is None:
-            return
-        with self._lock, closing(self.connection.cursor()) as cursor:
-            entry_ids = cursor.execute(
-                "SELECT id FROM entries WHERE created_at + ? < ?",
-                [self.default_ttl, datetime.now().timestamp()],
-            ).fetchall()
-            for (entry_id,) in entry_ids:
-                self.remove_entry(uuid.UUID(bytes=entry_id))
+                    request = completed_entry.request
+                    response = completed_entry.response
+                    request_and_response_size = measure_entry_size(request, response)
+
+                    cursor.execute(
+                        "UPDATE entries SET size = ?, time_last_accessed = ? WHERE id = ?",
+                        (
+                            request_and_response_size + starting_size,
+                            datetime.now().timestamp(),
+                            id.bytes,
+                        ),
+                    )
+                    accumulated_size_state = {
+                        "size": starting_size,
+                        "exceed_handled": False,
+                    }
+                    completed_entry.request.stream = self._check_max_stream_bytes(
+                        completed_entry.id,
+                        completed_entry.request.stream,
+                        accumulated_size_state,
+                    )
+                    completed_entry.response.stream = self._check_max_stream_bytes(
+                        completed_entry.id,
+                        completed_entry.response.stream,
+                        accumulated_size_state,
+                    )
+
+                    connection.commit()
+                    cursor.close()
+
+                return completed_entry
 
     @with_thread_lock
     def clear(self):

--- a/tiled/client/context.py
+++ b/tiled/client/context.py
@@ -21,7 +21,7 @@ from .._version import __version__ as tiled_version
 from ..utils import UNSET, DictView, parse_time_string
 from .auth import CannotRefreshAuthentication, TiledAuth, build_refresh_request
 from .decoders import SUPPORTED_DECODERS
-from .transport import Transport
+from .transport import TiledTransport
 from .utils import (
     DEFAULT_TIMEOUT_PARAMS,
     MSGPACK_MIME_TYPE,
@@ -239,7 +239,7 @@ class Context:
         )
         if app is None:
             client = httpx.Client(
-                transport=Transport(cache=cache, limits=limits),
+                transport=TiledTransport(cache=cache, limits=limits),
                 verify=verify,
                 timeout=timeout,
                 follow_redirects=True,
@@ -271,7 +271,7 @@ class Context:
             client.headers = headers
             # Do this in the setter to avoid being overwritten.
             client.follow_redirects = True
-            client._transport = Transport(transport=client._transport, cache=cache)
+            client._transport = TiledTransport(transport=client._transport, cache=cache)
             client.__enter__()
             # The TestClient is meant to be used only as a context manager,
             # where the context starts and stops and the wrapped ASGI app.
@@ -435,7 +435,7 @@ class Context:
         )
         self.http_client = httpx.Client(
             verify=verify,
-            transport=Transport(cache=cache, limits=limits),
+            transport=TiledTransport(cache=cache, limits=limits),
             cookies=cookies,
             timeout=timeout,
             headers=headers,

--- a/tiled/client/transport.py
+++ b/tiled/client/transport.py
@@ -5,21 +5,21 @@ in accordance with its BSD-3 license
 import typing as tp
 
 import httpx
+from hishel import CacheOptions, SpecificationPolicy
+from hishel.httpx import SyncCacheTransport
 
-from .cache import Cache
-from .cache_control import ByteStreamWrapper, CacheControl
+from .cache import TiledCache
 from .logger import collect_request, collect_response, log_request, log_response, logger
 from .utils import TiledResponse
 
 
-class Transport(httpx.BaseTransport):
-    """Custom transport, implementing caching and custom compression encodings.
+class TiledTransport(httpx.BaseTransport):
+    """Custom transport, implementing caching.
 
     Args:
         transport (optional): an existing httpx transport, if no transport
             is given, defaults to an httpx.HTTPTransport with default args.
-        cache (optional): cache to use with this transport, defaults to
-            httpx_cache.DictCache
+        cache (optional): cache to use with this transport.
         cacheable_methods: methods that are allowed to be cached, defaults to ['GET']
         cacheable_status_codes: status codes that are allowed to be cached,
             defaults to: (200, 203, 300, 301, 308)
@@ -29,7 +29,7 @@ class Transport(httpx.BaseTransport):
         self,
         *,
         transport: tp.Optional[httpx.BaseTransport] = None,
-        cache: tp.Optional[Cache] = None,
+        cache: tp.Optional[TiledCache] = None,
         limits: tp.Optional[httpx.Limits] = None,
         cacheable_methods: tp.Tuple[str, ...] = ("GET",),
         cacheable_status_codes: tp.Tuple[int, ...] = (
@@ -40,19 +40,40 @@ class Transport(httpx.BaseTransport):
             httpx.codes.PERMANENT_REDIRECT,
         ),
         always_cache: bool = False,
+        shared: bool = True,
     ):
-        self.controller = CacheControl(
-            cacheable_methods=cacheable_methods,
-            cacheable_status_codes=cacheable_status_codes,
-            always_cache=always_cache,
-        )
+        self.cacheable_methods = cacheable_methods
         if transport is not None:
             self.transport = transport
         elif limits is not None:
             self.transport = httpx.HTTPTransport(limits=limits)
         else:
             self.transport = httpx.HTTPTransport()
-        self.cache = cache
+        self.shared = shared
+        self.cache = cache  # This sets the cache from the cache.setter below
+
+    @property
+    def cache(self):
+        return self._cache
+
+    @cache.setter
+    def cache(self, cache):
+        # This is in case the cache changes to prevent a stale transport by reapplying the wrapper
+        # so that SyncCacheTransport doesn't continue to point at the old storage
+        self._cache = cache
+        if cache is None:
+            self._active_transport = self.transport
+        else:
+            # wrapper so we can use the Hishel transport. Handles writing etc for us
+            self._active_transport = SyncCacheTransport(
+                policy=SpecificationPolicy(
+                    cache_options=CacheOptions(
+                        supported_methods=self.cacheable_methods, shared=self.shared
+                    )
+                ),
+                next_transport=self.transport,
+                storage=cache,
+            )
 
     def close(self) -> None:
         self.transport.close()
@@ -60,101 +81,29 @@ class Transport(httpx.BaseTransport):
             self.cache.close()
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
-        # check if request is cacheable
-        if (self.cache is not None) and self.controller.is_request_cacheable(request):
-            if __debug__:
-                logger.debug("Checking cache for: %s", request)
-            cached_response = self.cache.get(request)
-            if cached_response is not None:
-                if self.controller.is_response_fresh(
-                    request=request, response=cached_response
-                ):
-                    if not self.controller.needs_revalidation(
-                        request=request, response=cached_response
-                    ):
-                        if __debug__:
-                            logger.debug("Using cached response for: %s", request)
-                            log_request(request)
-                            collect_request(request)
-                        return cached_response
-                    if __debug__:
-                        logger.debug("Revalidating cached response for: %s", request)
-                    request.headers["If-None-Match"] = cached_response.headers["ETag"]
-                else:
-                    if __debug__:
-                        logger.debug("Cached response is stale, deleting: %s", request)
-                    self.cache.delete(request)
-            else:
-                if __debug__:
-                    logger.debug(
-                        "No valid cached response found in cache for: %s", request
-                    )
-
         # Call original transport
         if __debug__:
             log_request(request)
             collect_request(request)
-        response = self.transport.handle_request(request)
+        response = self._active_transport.handle_request(request)
         response.__class__ = TiledResponse
         response.request = request
+        if self.cache is not None:
+            from_cache = False
+            from_cache = response.extensions.get("hishel_from_cache")
+            if from_cache:
+                logger.info("Cache hit")
+            else:
+                logger.info("Cache miss")
         if __debug__:
             # Log the actual server traffic, not the cached response.
             log_response(response)
             # But, below _collect_ the response with the content in it.
-
-        if self.cache is not None:
-            if response.status_code == httpx.codes.NOT_MODIFIED:
-                if __debug__:
-                    logger.debug(
-                        "Server validated as fresh cached entry for: %s", request
-                    )
-                    collect_response(cached_response)
-                return cached_response
-
-            if self.controller.is_response_cacheable(
-                request=request, response=response
-            ):
-                if self.cache.readonly:
-                    if __debug__:
-                        logger.debug("Cache is read-only; will not store")
-                elif not self.cache.write_safe():
-                    if __debug__:
-                        logger.debug(
-                            "Cannot write to cache from another thread; will not store"
-                        )
-                else:
-                    if hasattr(response, "_content"):
-                        is_stored = self.cache.set(request=request, response=response)
-                        if __debug__:
-                            if is_stored:
-                                logger.debug("Caching response for: %s", request)
-                            else:
-                                logger.debug(
-                                    "Declined to store large response for: %s", request
-                                )
-                    else:
-                        # Wrap the response with cache callback:
-                        def _callback(content: bytes) -> None:
-                            is_stored = self.cache.set(
-                                request=request, response=response, content=content
-                            )
-                            if __debug__:
-                                if is_stored:
-                                    logger.debug("Caching response for: %s", request)
-                                else:
-                                    logger.debug(
-                                        "Declined to store large response for: %s",
-                                        request,
-                                    )
-
-                        response.stream = ByteStreamWrapper(
-                            stream=response.stream, callback=_callback  # type: ignore
-                        )
-        if __debug__:
             collect_response(response)
         return response
 
 
+# TODO: this needs to be updated for the new client-side cache with Hishel
 # For when we implement an Async client
 #
 # class AsyncCacheControlTransport(httpx.AsyncBaseTransport):

--- a/tiled/client/transport.py
+++ b/tiled/client/transport.py
@@ -40,7 +40,7 @@ class TiledTransport(httpx.BaseTransport):
             httpx.codes.PERMANENT_REDIRECT,
         ),
         always_cache: bool = False,
-        shared: bool = True,
+        shared: bool = False,
     ):
         self.cacheable_methods = cacheable_methods
         if transport is not None:


### PR DESCRIPTION
This PR refactors the Tiled client-side cache to integrate the Hishel library. This includes maintaining functionality necessary for Hishel, such as size and readonly constraints. This PR includes modifications to the client transport and context in addition to the client-side cache. It also has modifications to the documentation and the addition of a new documentation page. 

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
